### PR TITLE
Fixed getting 'vpn_remote_line' for files configs without spaces

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -117,7 +117,7 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	if [[ "${VPN_TYPE}" == "openvpn" ]]; then
 		export vpn_remote_line=$(cat "${VPN_CONFIG}" | grep -P -o -m 1 '(?<=^remote\s)[^\n\r]+' | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')
 	else
-		export vpn_remote_line=$(cat "${VPN_CONFIG}" | grep -P -o -m 1 '(?<=^Endpoint\s)[^\n\r]+' | sed -e 's~^[=\ ]*~~')
+		export vpn_remote_line=$(cat "${VPN_CONFIG}" | grep -P -o -m 1 '(?<=^Endpoint)(\s{0,})[^\n\r]+' | sed -e 's~^[=\ ]*~~')
 	fi
 
 	if [[ ! -z "${vpn_remote_line}" ]]; then

--- a/qbittorrent/start.sh
+++ b/qbittorrent/start.sh
@@ -6,10 +6,10 @@ fi
 # Set the correct rights accordingly to the PUID and PGID on /config/qBittorrent
 chown -R ${PUID}:${PGID} /config/qBittorrent
 
-# Set the rights on the /blackhole folder
+# Set the rights on the /downloads folder
 chown -R ${PUID}:${PGID} /downloads
 
-# Check if ServerConfig.json exists, if not, copy the template over
+# Check if qBittorrent.conf exists, if not, copy the template over
 if [ ! -e /config/qBittorrent/config/qBittorrent.conf ]; then
 	echo "[WARNING] qBittorrent.conf is missing, this is normal for the first launch! Copying template." | ts '%Y-%m-%d %H:%M:%.S'
 	cp /etc/qbittorrent/qBittorrent.conf /config/qBittorrent/config/qBittorrent.conf


### PR DESCRIPTION
Example of a Wireguard config that did not work:
Endpoint=127.0.0.1:443

While this did:
Endpoint = 127.0.0.1:443