### PR TITLE
Prevent unnecessary message of `wg-quick down` before running `wg-quick up`

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -267,7 +267,7 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	else
 		echo "[INFO] Starting WireGuard..." | ts '%Y-%m-%d %H:%M:%.S'
 		cd /config/wireguard
-		if ip link | grep -q $VPN_CONFIG; then
+		if ip link | grep -q `basename -s .conf $VPN_CONFIG`; then
 			wg-quick down $VPN_CONFIG || echo "WireGuard is down already" | ts '%Y-%m-%d %H:%M:%.S' # Run wg-quick down as an extra safeguard in case WireGuard is still up for some reason
 		fi
 		sleep 0.5 # Just to give WireGuard a bit to go down

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -267,7 +267,9 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	else
 		echo "[INFO] Starting WireGuard..." | ts '%Y-%m-%d %H:%M:%.S'
 		cd /config/wireguard
-		wg-quick down $VPN_CONFIG || echo "WireGuard is down already" | ts '%Y-%m-%d %H:%M:%.S' # Run wg-quick down as an extra safeguard in case WireGuard is still up for some reason
+		if ip link | grep -q $VPN_CONFIG; then
+			wg-quick down $VPN_CONFIG || echo "WireGuard is down already" | ts '%Y-%m-%d %H:%M:%.S' # Run wg-quick down as an extra safeguard in case WireGuard is still up for some reason
+		fi
 		sleep 0.5 # Just to give WireGuard a bit to go down
 		wg-quick up $VPN_CONFIG
 		#exec /bin/bash /etc/openvpn/openvpn.init start &


### PR DESCRIPTION
`wg-quick down wg0` is called even if the interface doesn't exist - this change tests to see if the interface exists first. alternatively, it could be done with the following one-liner:

LINE 270:
     `ip link | grep -q $VPN_CONFIG && wg-quick down $VPN_CONFIG || echo "WireGuard is down already" | ts '%Y-%m-%d %H:%M:%.S'`