### PR TITLE
Libtorrent 2.0, code clean-up, IPv6 Issue focefully fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN apt update \
     jq \
     libboost-system-dev \
     libssl-dev \
-    && LIBTORRENT_ASSETS=$(curl -sX GET "https://api.github.com/repos/arvidn/libtorrent/releases" | jq '.[] | select(.prerelease==false) | select(.target_commitish=="RC_1_2") | .assets_url' | head -n 1 | tr -d '"') \
+    && LIBTORRENT_ASSETS=$(curl -sX GET "https://api.github.com/repos/arvidn/libtorrent/releases" | jq '.[] | select(.prerelease==false) | select(.target_commitish=="RC_2_0") | .assets_url' | head -n 1 | tr -d '"') \
     && LIBTORRENT_DOWNLOAD_URL=$(curl -sX GET ${LIBTORRENT_ASSETS} | jq '.[0] .browser_download_url' | tr -d '"') \
     && LIBTORRENT_NAME=$(curl -sX GET ${LIBTORRENT_ASSETS} | jq '.[0] .name' | tr -d '"') \
     && curl -o /opt/${LIBTORRENT_NAME} -L ${LIBTORRENT_DOWNLOAD_URL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@ RUN apt update \
     curl \
     ca-certificates \
     g++ \
-    && curl -o /opt/boost_1_75_0.tar.gz -L https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.gz \
-    && tar -xzf /opt/boost_1_75_0.tar.gz -C /opt \
-    && cd /opt/boost_1_75_0 \
+    libxml2-utils \
+    && BOOST_VERSION_DOT=$(curl -sX GET "https://www.boost.org/feed/news.rss" | xmllint --xpath '//rss/channel/item/title/text()' - | awk -F 'Version' '{print $2 FS}' - | sed -e 's/Version//g;s/\ //g' | awk 'NR==1{print $1}' -) \
+    && BOOST_VERSION=$(echo ${BOOST_VERSION_DOT} | head -n 1 | sed -e 's/\./_/g') \
+    && curl -o /opt/boost_${BOOST_VERSION}.tar.gz -L https://dl.bintray.com/boostorg/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.gz \
+    && tar -xzf /opt/boost_${BOOST_VERSION}.tar.gz -C /opt \
+    && cd /opt/boost_${BOOST_VERSION} \
     && ./bootstrap.sh --prefix=/usr \
     && ./b2 --prefix=/usr install \
     && cd /opt \
@@ -25,6 +28,7 @@ RUN apt update \
     curl \
     ca-certificates \
     g++ \
+    libxml2-utils \
     && apt-get clean \
     && apt -y autoremove \
     && rm -rf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt update \
     && NINJA_ASSETS=$(curl -sX GET "https://api.github.com/repos/ninja-build/ninja/releases" | jq '.[] | select(.prerelease==false) | .assets_url' | head -n 1 | tr -d '"') \
     && NINJA_DOWNLOAD_URL=$(curl -sX GET ${NINJA_ASSETS} | jq '.[] | select(.name | contains("ninja-linux")) .browser_download_url' | tr -d '"') \
     && curl -o /opt/ninja-linux.zip -L ${NINJA_DOWNLOAD_URL} \
-    && unzip /opt/ninja-linux.zip \
-    && mv ninja /usr/local/bin/ninja \
+    && unzip /opt/ninja-linux.zip -d /opt \
+    && mv /opt/ninja /usr/local/bin/ninja \
     && chmod +x /usr/local/bin/ninja \
     && rm -rf /opt/* \
     && apt purge -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,31 @@ RUN usermod -u 99 nobody
 # Make directories
 RUN mkdir -p /downloads /config/qBittorrent /etc/openvpn /etc/qbittorrent
 
+# Install boost
+RUN apt update \
+    && apt -y upgrade \
+    && apt -y install --no-install-recommends \
+    curl \
+    ca-certificates \
+    g++ \
+    && curl -o /opt/boost_1_75_0.tar.gz -L https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.gz \
+    && tar -xzf /opt/boost_1_75_0.tar.gz -C /opt \
+    && cd /opt/boost_1_75_0 \
+    && ./bootstrap.sh --prefix=/usr \
+    && ./b2 --prefix=/usr install \
+    && cd /opt \
+    && rm -rf /opt/* \
+    && apt -y purge \
+    curl \
+    ca-certificates \
+    g++ \
+    && apt-get clean \
+    && apt -y autoremove \
+    && rm -rf \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
 # Install Ninja
 RUN apt update \
     && apt upgrade -y \
@@ -66,7 +91,6 @@ RUN apt update \
     ca-certificates \
     curl \
     jq \
-    libboost-system-dev \
     libssl-dev \
     && LIBTORRENT_ASSETS=$(curl -sX GET "https://api.github.com/repos/arvidn/libtorrent/releases" | jq '.[] | select(.prerelease==false) | select(.target_commitish=="RC_2_0") | .assets_url' | head -n 1 | tr -d '"') \
     && LIBTORRENT_DOWNLOAD_URL=$(curl -sX GET ${LIBTORRENT_ASSETS} | jq '.[0] .browser_download_url' | tr -d '"') \
@@ -85,7 +109,6 @@ RUN apt update \
     ca-certificates \
     curl \
     jq \
-    libboost-system-dev \
     libssl-dev \
     && apt-get clean \
     && apt autoremove -y \
@@ -103,7 +126,6 @@ RUN apt update \
     curl \
     git \
     jq \
-    libboost-system-dev \
     libssl-dev \
     pkg-config \
     qtbase5-dev \
@@ -125,7 +147,6 @@ RUN apt update \
     curl \
     git \
     jq \
-    libboost-system-dev \
     libssl-dev \
     pkg-config \
     qtbase5-dev \
@@ -149,7 +170,6 @@ RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.li
     ipcalc \
     iptables \
     kmod \
-    libboost-system1.67.0 \
     libqt5network5 \
     libqt5xml5 \
     libssl1.1 \

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Docker container which runs the latest [qBittorrent](https://github.com/qbittorr
 * Base: Debian 10-slim
 * [qBittorrent](https://github.com/qbittorrent/qBittorrent) compiled from source
 * [libtorrent](https://github.com/arvidn/libtorrent) compiled from source
+* Compiled with the latest version of [Boost](https://www.boost.org/)
+* Compiled with the latest versions of [CMake](https://cmake.org/)
 * Selectively enable or disable WireGuard or OpenVPN support
 * IP tables killswitch to prevent IP leaking when VPN connection fails
-* Specify name servers to add to container
-* Configure UID and GID for config files and /downloads for qBittorrent
+* Configurable UID and GID for config files and /downloads for qBittorrent
 * Created with [Unraid](https://unraid.net/) in mind
-* BitTorrent port 8999 by default
+* BitTorrent port 8999 exposed by default
 
 # Run container from Docker registry
 The container is available from the Docker registry and this is the simplest way to get it  
@@ -29,7 +30,6 @@ $ docker run --privileged  -d \
               -e "VPN_ENABLED=yes" \
               -e "VPN_TYPE=wireguard" \
               -e "LAN_NETWORK=192.168.0.0/24" \
-              -e "NAME_SERVERS=1.1.1.1,1.0.0.1" \
               -p 8080:8080 \
               --restart unless-stopped \
               dyonr/qbittorrentvpn
@@ -46,7 +46,6 @@ $ docker run --privileged  -d \
 |`LAN_NETWORK`| Yes (atleast one) | Comma delimited local Network's with CIDR notation |`LAN_NETWORK=192.168.0.0/24,10.10.0.0/24`||
 |`ENABLE_SSL`| No | Let the container handle SSL (yes/no)? |`ENABLE_SSL=yes`|`yes`|
 |`NAME_SERVERS`| No | Comma delimited name servers |`NAME_SERVERS=1.1.1.1,1.0.0.1`|`1.1.1.1,1.0.0.1`|
-|`LEGACY_IPTABLES`| No | Make use of iptables-legacy instead of nf_tables |`LEGACY_IPTABLES=true`|``|
 |`PUID`| No | UID applied to /config files and /downloads |`PUID=99`|`99`|
 |`PGID`| No | GID applied to /config files and /downloads  |`PGID=100`|`100`|
 |`UMASK`| No | |`UMASK=002`|`002`|
@@ -55,8 +54,6 @@ $ docker run --privileged  -d \
 |`HEALTH_CHECK_SILENT`| No |Set to `1` to supress the 'Network is up' message. Defaults to `1` if unset.|`HEALTH_CHECK_SILENT=1`|`1`|
 |`INSTALL_PYTHON3`| No |Set this to `yes` to let the container install Python3.|`INSTALL_PYTHON3=yes`|`no`|
 |`ADDITIONAL_PORTS`| No |Adding a comma delimited list of ports will allow these ports via the iptables script.|`ADDITIONAL_PORTS=1234,8112`||
-
-
 
 ## Volumes
 | Volume | Required | Function | Example |
@@ -72,7 +69,7 @@ $ docker run --privileged  -d \
 | `8999` | UDP | Yes | qBittorrent UDP Listening Port | `8999:8999/udp`|
 
 # Access the WebUI
-Access http://IPADDRESS:PORT from a browser on the same network. (for example: http://192.168.0.90:8080)
+Access https://IPADDRESS:PORT from a browser on the same network. (for example: https://192.168.0.90:8080)
 
 ## Default Credentials
 
@@ -114,4 +111,3 @@ Using the latest stable verison of Docker is always recommended. Support for old
 [MarkusMcNugen/docker-qBittorrentvpn](https://github.com/MarkusMcNugen/docker-qBittorrentvpn)  
 [DyonR/jackettvpn](https://github.com/DyonR/jackettvpn)  
 This projects originates from MarkusMcNugen/docker-qBittorrentvpn, but forking was not possible since DyonR/jackettvpn uses the fork already.
-

--- a/README.md
+++ b/README.md
@@ -105,15 +105,6 @@ User ID (PUID) and Group ID (PGID) can be found by issuing the following command
 id <username>
 ```
 
-## Known issue IPv6
-There is a known issue with VPN providers that support IPv6.  
-To workaround this issue, you need to add the folling lines to your .ovpn file:
-```
-pull-filter ignore 'route-ipv6'
-pull-filter ignore 'ifconfig-ipv6'
-```
-Thanks to [Technikte](https://github.com/Technikte) in [Issue #19](https://github.com/DyonR/docker-Jackettvpn/issues/19).
-
 # Issues
 If you are having issues with this container please submit an issue on GitHub.
 Please provide logs, docker version and other information that can simplify reproducing the issue.

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -262,7 +262,7 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	if [[ "${VPN_TYPE}" == "openvpn" ]]; then
 		echo "[INFO] Starting OpenVPN..." | ts '%Y-%m-%d %H:%M:%.S'
 		cd /config/openvpn
-		exec openvpn --config "${VPN_CONFIG}" &
+		exec openvpn --pull-filter ignore route-ipv6 --pull-filter ignore ifconfig-ipv6 --config "${VPN_CONFIG}" &
 		#exec /bin/bash /etc/openvpn/openvpn.init start &
 	else
 		echo "[INFO] Starting WireGuard..." | ts '%Y-%m-%d %H:%M:%.S'

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -21,18 +21,18 @@ else
 	export VPN_ENABLED="yes"
 fi
 
-export LEGACY_IPTABLES=$(echo "${LEGACY_IPTABLES,,}")
-echo "[INFO] LEGACY_IPTABLES is set to '${LEGACY_IPTABLES}'" | ts '%Y-%m-%d %H:%M:%.S'
-if [[ $LEGACY_IPTABLES == "1" || $LEGACY_IPTABLES == "true" || $LEGACY_IPTABLES == "yes" ]]; then
-	echo "[INFO] Linking /usr/sbin/iptables-legacy to /usr/sbin/iptables" | ts '%Y-%m-%d %H:%M:%.S'
-	ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables > /dev/null 2>&1
-	#echo "[INFO] Linking /usr/sbin/iptables-legacy-save to /usr/sbin/iptables-save" | ts '%Y-%m-%d %H:%M:%.S'
-	#ln -sf /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save > /dev/null 2>&1
-	#echo "[INFO] Linking /usr/sbin/iptables-legacy-restore to /usr/sbin/iptables-restore" | ts '%Y-%m-%d %H:%M:%.S'
-	#ln -sf /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore > /dev/null 2>&1
-else
-	echo "[INFO] Not making any changes to iptables" | ts '%Y-%m-%d %H:%M:%.S'
-fi
+# export LEGACY_IPTABLES=$(echo "${LEGACY_IPTABLES,,}")
+# echo "[INFO] LEGACY_IPTABLES is set to '${LEGACY_IPTABLES}'" | ts '%Y-%m-%d %H:%M:%.S'
+# if [[ $LEGACY_IPTABLES == "1" || $LEGACY_IPTABLES == "true" || $LEGACY_IPTABLES == "yes" ]]; then
+#	echo "[INFO] Linking /usr/sbin/iptables-legacy to /usr/sbin/iptables" | ts '%Y-%m-%d %H:%M:%.S'
+#	ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables > /dev/null 2>&1
+#	echo "[INFO] Linking /usr/sbin/iptables-legacy-save to /usr/sbin/iptables-save" | ts '%Y-%m-%d %H:%M:%.S'
+#	ln -sf /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save > /dev/null 2>&1
+#	echo "[INFO] Linking /usr/sbin/iptables-legacy-restore to /usr/sbin/iptables-restore" | ts '%Y-%m-%d %H:%M:%.S'
+#	ln -sf /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore > /dev/null 2>&1
+# else
+#	echo "[INFO] Not making any changes to iptables" | ts '%Y-%m-%d %H:%M:%.S'
+# fi
 
 if [[ $VPN_ENABLED == "yes" ]]; then
 	# Check if VPN_TYPE is set.
@@ -232,7 +232,7 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	fi
 
 elif [[ $VPN_ENABLED == "no" ]]; then
-	echo "[WARNING] !!IMPORTANT!! You have set the VPN to disabled, you will NOT be secure!" | ts '%Y-%m-%d %H:%M:%.S'
+	echo "[WARNING] !!IMPORTANT!! You have set the VPN to disabled, your connection will NOT be secure!" | ts '%Y-%m-%d %H:%M:%.S'
 fi
 
 
@@ -269,8 +269,8 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 		cd /config/wireguard
 		if ip link | grep -q `basename -s .conf $VPN_CONFIG`; then
 			wg-quick down $VPN_CONFIG || echo "WireGuard is down already" | ts '%Y-%m-%d %H:%M:%.S' # Run wg-quick down as an extra safeguard in case WireGuard is still up for some reason
+			sleep 0.5 # Just to give WireGuard a bit to go down
 		fi
-		sleep 0.5 # Just to give WireGuard a bit to go down
 		wg-quick up $VPN_CONFIG
 		#exec /bin/bash /etc/openvpn/openvpn.init start &
 	fi

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -26,10 +26,10 @@ echo "[INFO] LEGACY_IPTABLES is set to '${LEGACY_IPTABLES}'" | ts '%Y-%m-%d %H:%
 if [[ $LEGACY_IPTABLES == "1" || $LEGACY_IPTABLES == "true" || $LEGACY_IPTABLES == "yes" ]]; then
 	echo "[INFO] Linking /usr/sbin/iptables-legacy to /usr/sbin/iptables" | ts '%Y-%m-%d %H:%M:%.S'
 	ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables > /dev/null 2>&1
-	echo "[INFO] Linking /usr/sbin/iptables-legacy-save to /usr/sbin/iptables-save" | ts '%Y-%m-%d %H:%M:%.S'
-	ln -sf /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save > /dev/null 2>&1
-	echo "[INFO] Linking /usr/sbin/iptables-legacy-restore to /usr/sbin/iptables-restore" | ts '%Y-%m-%d %H:%M:%.S'
-	ln -sf /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore > /dev/null 2>&1
+	#echo "[INFO] Linking /usr/sbin/iptables-legacy-save to /usr/sbin/iptables-save" | ts '%Y-%m-%d %H:%M:%.S'
+	#ln -sf /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save > /dev/null 2>&1
+	#echo "[INFO] Linking /usr/sbin/iptables-legacy-restore to /usr/sbin/iptables-restore" | ts '%Y-%m-%d %H:%M:%.S'
+	#ln -sf /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore > /dev/null 2>&1
 else
 	echo "[INFO] Not making any changes to iptables" | ts '%Y-%m-%d %H:%M:%.S'
 fi

--- a/qbittorrent/start.sh
+++ b/qbittorrent/start.sh
@@ -39,36 +39,32 @@ if [[ ${ENABLE_SSL} == 'yes' ]]; then
 		openssl req -new -x509 -nodes -out /config/qBittorrent/config/WebUICertificate.crt -keyout /config/qBittorrent/config/WebUIKey.key -subj "/C=NL/ST=localhost/L=localhost/O=/OU=/CN="
 		chown -R ${PUID}:${PGID} /config/qBittorrent/config
 	fi
-	if grep -Fxq 'WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt' "/config/qBittorrent/config/qBittorrent.conf" 
-		then
-			echo "[INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUICertificate.crt loaded, nothing to do." | ts '%Y-%m-%d %H:%M:%.S'
-		else
-			echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUICertificate.crt loaded. Added it to the config." | ts '%Y-%m-%d %H:%M:%.S'
-			echo 'WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt' >> "/config/qBittorrent/config/qBittorrent.conf"
+	if grep -Fxq 'WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt' "/config/qBittorrent/config/qBittorrent.conf"; then
+		echo "[INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUICertificate.crt loaded, nothing to do." | ts '%Y-%m-%d %H:%M:%.S'
+	else
+		echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUICertificate.crt loaded. Added it to the config." | ts '%Y-%m-%d %H:%M:%.S'
+		echo 'WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt' >> "/config/qBittorrent/config/qBittorrent.conf"
 	fi
-	if grep -Fxq 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' "/config/qBittorrent/config/qBittorrent.conf" 
-		then
-			echo "[INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUIKey.key loaded, nothing to do." | ts '%Y-%m-%d %H:%M:%.S'
-		else
-			echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUIKey.key loaded. Added it to the config." | ts '%Y-%m-%d %H:%M:%.S'
-			echo 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' >> "/config/qBittorrent/config/qBittorrent.conf"
+	if grep -Fxq 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' "/config/qBittorrent/config/qBittorrent.conf"; then
+		echo "[INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUIKey.key loaded, nothing to do." | ts '%Y-%m-%d %H:%M:%.S'
+	else
+		echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUIKey.key loaded. Added it to the config." | ts '%Y-%m-%d %H:%M:%.S'
+		echo 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' >> "/config/qBittorrent/config/qBittorrent.conf"
 	fi
-	if grep -xq 'WebUI\\HTTPS\\Enabled=true\|WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"
-		then
-			if grep -xq 'WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"
-				then
-					echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled set to false, changing it to true." | ts '%Y-%m-%d %H:%M:%.S'
-					sed -i 's/WebUI\\HTTPS\\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"
-				else
-					echo "[INFO] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled already set to true." | ts '%Y-%m-%d %H:%M:%.S'
-			fi
+	if grep -xq 'WebUI\\HTTPS\\Enabled=true\|WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
+		if grep -xq 'WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
+			echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled set to false, changing it to true." | ts '%Y-%m-%d %H:%M:%.S'
+			sed -i 's/WebUI\\HTTPS\\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"
 		else
-			echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUI\HTTPS\Enabled loaded. Added it to the config." | ts '%Y-%m-%d %H:%M:%.S'
-			echo 'WebUI\HTTPS\Enabled=true' >> "/config/qBittorrent/config/qBittorrent.conf"
+			echo "[INFO] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled already set to true." | ts '%Y-%m-%d %H:%M:%.S'
 		fi
-		else
-			echo "[WARNING] ENABLE_SSL is set to ${ENABLE_SSL}, SSL is not enabled. This could cause issues with logging if other apps use the same Cookie name (SID)." | ts '%Y-%m-%d %H:%M:%.S'
-			echo "[WARNING] If you manage the SSL config yourself, you can ignore this." | ts '%Y-%m-%d %H:%M:%.S'
+	else
+		echo "[WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUI\HTTPS\Enabled loaded. Added it to the config." | ts '%Y-%m-%d %H:%M:%.S'
+		echo 'WebUI\HTTPS\Enabled=true' >> "/config/qBittorrent/config/qBittorrent.conf"
+	fi
+else
+	echo "[WARNING] ENABLE_SSL is set to ${ENABLE_SSL}, SSL is not enabled. This could cause issues with logging if other apps use the same Cookie name (SID)." | ts '%Y-%m-%d %H:%M:%.S'
+	echo "[WARNING] If you manage the SSL config yourself, you can ignore this." | ts '%Y-%m-%d %H:%M:%.S'
 fi
 
 # Check if the PGID exists, if not create the group with the name 'qbittorrent'


### PR DESCRIPTION
This pull request comes with the following features:  
* Switch to the Libtorrent RC_2_0 tag instead of RC_1_2.  
* Self-compilation of Boost to stay up to date with the newest software.  
* Forcing a fix of the IPv6 Issues people were reporting with certain VPN providers. This is done by adding `--pull-filter ignore route-ipv6 --pull-filter ignore ifconfig-ipv6` to the openvpn command then running it.  
  
Code cleanup:  
* Fixed 'if... then;' consistency in the the SSL Certificate sectionof the qbittorrent start.sh script  
* Removal of an unnecessary `wg-quick down` message  
* Removal of obsolete info in README.md