### PR TITLE
Revert back to libtorrent RC_1_2 branch for stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN apt update \
     curl \
     jq \
     libssl-dev \
-    && LIBTORRENT_ASSETS=$(curl -sX GET "https://api.github.com/repos/arvidn/libtorrent/releases" | jq '.[] | select(.prerelease==false) | select(.target_commitish=="RC_2_0") | .assets_url' | head -n 1 | tr -d '"') \
+    && LIBTORRENT_ASSETS=$(curl -sX GET "https://api.github.com/repos/arvidn/libtorrent/releases" | jq '.[] | select(.prerelease==false) | select(.target_commitish=="RC_1_2") | .assets_url' | head -n 1 | tr -d '"') \
     && LIBTORRENT_DOWNLOAD_URL=$(curl -sX GET ${LIBTORRENT_ASSETS} | jq '.[0] .browser_download_url' | tr -d '"') \
     && LIBTORRENT_NAME=$(curl -sX GET ${LIBTORRENT_ASSETS} | jq '.[0] .name' | tr -d '"') \
     && curl -o /opt/${LIBTORRENT_NAME} -L ${LIBTORRENT_DOWNLOAD_URL} \

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ id <username>
 ```
 
 # Issues
-If you are having issues with this container please submit an issue on GitHub.
-Please provide logs, Docker version and other information that can simplify reproducing the issue.
+If you are having issues with this container please submit an issue on GitHub.  
+Please provide logs, Docker version and other information that can simplify reproducing the issue.  
 If possible, always use the most up to date version of Docker, you operating system, kernel and the container itself. Support is always a best-effort basis.
 
-### Credits:  
+### Credits:
 [MarkusMcNugen/docker-qBittorrentvpn](https://github.com/MarkusMcNugen/docker-qBittorrentvpn)  
 [DyonR/jackettvpn](https://github.com/DyonR/jackettvpn)  
 This projects originates from MarkusMcNugen/docker-qBittorrentvpn, but forking was not possible since DyonR/jackettvpn uses the fork already.


### PR DESCRIPTION
I've decided to roll back to the libtorrent RC_1_2 branch since I've experienced problems with the RC_2_0 branch, which has been reported;  
https://github.com/qbittorrent/qBittorrent/issues/14321