### PR TITLE
Different way to search for existing PUID

### DIFF
--- a/qbittorrent/start.sh
+++ b/qbittorrent/start.sh
@@ -77,7 +77,7 @@ else
 fi
 
 # Check if the PUID exists, if not create the user with the name 'qbittorrent', with the correct group
-grep $"${PUID}:" /etc/passwd > /dev/null 2>&1
+id ${PUID} > /dev/null 2>&1
 if [ $? -eq 0 ]; then
 	echo "[INFO] An user with PUID $PUID already exists in /etc/passwd, nothing to do." | ts '%Y-%m-%d %H:%M:%.S'
 else


### PR DESCRIPTION
Just grepping for PUID in /etc/passwd can accidentally catch group IDs with that same number. The `id` command returns whether or not there's a user with that ID more reliably.

(also not sure if making this change in master is fine, or if it should be in dev?)