### PR TITLE
Allow container to run wireguard without --privileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,6 +208,9 @@ RUN echo "deb http://deb.debian.org/debian/ buster non-free" > /etc/apt/sources.
     /tmp/* \
     /var/tmp/*
 
+# Remove src_valid_mark from wg-quick
+RUN sed -i /net\.ipv4\.conf\.all\.src_valid_mark/d `which wg-quick`
+
 VOLUME /config /downloads
 
 ADD openvpn/ /etc/openvpn/

--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ The container is available from the Docker registry and this is the simplest way
 To run the container use this command, with additional parameters, please refer to the Variables, Volumes, and Ports section:
 
 ```
-$ docker run --privileged  -d \
+$ docker run  -d \
               -v /your/config/path/:/config \
               -v /your/downloads/path/:/downloads \
               -e "VPN_ENABLED=yes" \
               -e "VPN_TYPE=wireguard" \
               -e "LAN_NETWORK=192.168.0.0/24" \
               -p 8080:8080 \
+              --cap-add NET_ADMIN \
+              --sysctl "net.ipv4.conf.all.src_valid_mark=1" \
               --restart unless-stopped \
               dyonr/qbittorrentvpn
 ```


### PR DESCRIPTION
When trying to use `wg-quick` in a unprivileged container you will run into various issues (in this case the container just keep restarting). I assume this is why the README suggests to use the `--privileged` flag. Using this flag, however, is obviously a security concern and shouldn't really be used unless it is 100% necessary (and in most cases it's not). 

The problem with `wg-quick` is that it tries to set the `src_valid_mark` sysctl option, but without `--privileged` it cannot. The solution here is to remove `src_valid_mark` from `wg-quick` and setting it at the containers runtime via `--sysctl "net.ipv4.conf.all.src_valid_mark=1"`. You'll also need `--cap-add NET_ADMIN` for everything to work. 

As far as testing goes, this is what I do in https://github.com/joe-p/docker-rtorrent-wireguard and I haven't had any problems running it for months. With this image specifically, I have it running in a docker-compose stack with IPv6 NAT and have everything fully functioning. 