### PR TITLE
Start VPN client whenever VPN_ENABLED is 1/true/yes

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -256,7 +256,7 @@ if [[ -z "${PGID}" ]]; then
 	export PGID="root"
 fi
 
-if [[ $VPN_ENABLED == "yes" ]]; then
+if [[ $VPN_ENABLED == "1" || $VPN_ENABLED == "true" || $VPN_ENABLED == "yes" ]]; then
 	if [[ "${VPN_TYPE}" == "openvpn" ]]; then
 		echo "[INFO] Starting OpenVPN..." | ts '%Y-%m-%d %H:%M:%.S'
 		cd /config/openvpn


### PR DESCRIPTION
VPN client was only started if VPN_ENABLED was "yes". However, earlier
in the start.sh file preparations were done whenever VPN_ENABLED was
either 1/true/yes.

Using a non-string 'yes' value in docker-compose.yaml, for instance,
would automatically make VPN_ENABLED take a value of "true", and that
would cause the VPN client not to start, without printing any sort of
warning or error.