### PR TITLE
Added HEALTH_CHECK_AMOUNT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ $ docker run  -d \
 |`HEALTH_CHECK_HOST`| No |This is the host or IP that the healthcheck script will use to check an active connection|`HEALTH_CHECK_HOST=one.one.one.one`|`one.one.one.one`|
 |`HEALTH_CHECK_INTERVAL`| No |This is the time in seconds that the container waits to see if the internet connection still works (check if VPN died)|`HEALTH_CHECK_INTERVAL=300`|`300`|
 |`HEALTH_CHECK_SILENT`| No |Set to `1` to supress the 'Network is up' message. Defaults to `1` if unset.|`HEALTH_CHECK_SILENT=1`|`1`|
+|`HEALTH_CHECK_AMOUNT`| No |The amount of pings that get send when checking for connection.|`HEALTH_CHECK_SILENT=1`|`1`|
 |`RESTART_CONTAINER`| No |Set to `no` to **disable** the automatic restart when the network is possibly down.|`RESTART_CONTAINER=yes`|`yes`|
 |`INSTALL_PYTHON3`| No |Set this to `yes` to let the container install Python3.|`INSTALL_PYTHON3=yes`|`no`|
 |`ADDITIONAL_PORTS`| No |Adding a comma delimited list of ports will allow these ports via the iptables script.|`ADDITIONAL_PORTS=1234,8112`||

--- a/qbittorrent/start.sh
+++ b/qbittorrent/start.sh
@@ -158,6 +158,7 @@ if [ -e /proc/$qbittorrentpid ]; then
 		echo "[INFO] HEALTH_CHECK_AMOUNT is not set. For now using default interval of ${DEFAULT_HEALTH_CHECK_AMOUNT}" | ts '%Y-%m-%d %H:%M:%.S'
 		HEALTH_CHECK_AMOUNT=${DEFAULT_HEALTH_CHECK_AMOUNT}
 	fi
+	echo "[INFO] HEALTH_CHECK_AMOUNT is set to ${HEALTH_CHECK_AMOUNT}" | ts '%Y-%m-%d %H:%M:%.S'
 
 	while true; do
 		# Ping uses both exit codes 1 and 2. Exit code 2 cannot be used for docker health checks, therefore we use this script to catch error code 2

--- a/qbittorrent/start.sh
+++ b/qbittorrent/start.sh
@@ -126,6 +126,7 @@ if [ -e /proc/$qbittorrentpid ]; then
 	DEFAULT_HOST="one.one.one.one"
 	INTERVAL=${HEALTH_CHECK_INTERVAL}
 	DEFAULT_INTERVAL=300
+	DEFAULT_HEALTH_CHECK_AMOUNT=1
 
 	# If host is zero (not set) default it to the DEFAULT_HOST variable
 	if [[ -z "${HOST}" ]]; then
@@ -152,9 +153,15 @@ if [ -e /proc/$qbittorrentpid ]; then
 		export RESTART_CONTAINER="yes"
 	fi
 
+	# If HEALTH_CHECK_AMOUNT is zero (not set) default it to DEFAULT_HEALTH_CHECK_AMOUNT
+	if [[ -z ${HEALTH_CHECK_AMOUNT} ]]; then
+		echo "[INFO] HEALTH_CHECK_AMOUNT is not set. For now using default interval of ${DEFAULT_HEALTH_CHECK_AMOUNT}" | ts '%Y-%m-%d %H:%M:%.S'
+		HEALTH_CHECK_AMOUNT=${DEFAULT_HEALTH_CHECK_AMOUNT}
+	fi
+
 	while true; do
 		# Ping uses both exit codes 1 and 2. Exit code 2 cannot be used for docker health checks, therefore we use this script to catch error code 2
-		ping -c 1 $HOST > /dev/null 2>&1
+		ping -c ${HEALTH_CHECK_AMOUNT} $HOST > /dev/null 2>&1
 		STATUS=$?
 		if [[ "${STATUS}" -ne 0 ]]; then
 			echo "[ERROR] Network is possibly down." | ts '%Y-%m-%d %H:%M:%.S'


### PR DESCRIPTION
Added HEALTH_CHECK_AMOUNT, this environment variable allows the user to customize how many `ping`s get send out when checking if the container is still up.  
Example: if HEALTH_CHECK_AMOUNT is set to 10, 1 or more pings need to succeed to keep the container alive.  
If all 10 fail, the container will restart.